### PR TITLE
Fix README + panic on parsing cf app output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ Binaries are available in the releases section.
 
 ### Usage
 ```sh
-cf recycle-app <APP NAME>
+cf recycle <APP NAME>
 ```

--- a/cf_recycle_plugin.go
+++ b/cf_recycle_plugin.go
@@ -116,7 +116,8 @@ func (cmd *CfRecycleCmd) getInstanceStatus(cliConnection plugin.CliConnection, i
 
 	for _, v := range instanceStatus {
 		v = strings.TrimSpace(v)
-		if strings.Fields(v)[0] == fmt.Sprintf("#%v", instance) {
+		fields := strings.Fields(v)
+		if len(fields) > 0 && fields[0] == fmt.Sprintf("#%v", instance) {
 			status = strings.Fields(v)[1]
 		}
 	}


### PR DESCRIPTION
Was running into panics from line 119 due to invalid indexes, when building with golang 1.8. This should resolve them